### PR TITLE
Quick fix to work around key validation

### DIFF
--- a/src/Controller/Adminhtml/Post/Livewire.php
+++ b/src/Controller/Adminhtml/Post/Livewire.php
@@ -97,6 +97,11 @@ class Livewire extends Action
         }
     }
 
+    public function _processUrlKeys()
+    {
+        return true;
+    }
+
     /**
      * @throws NoSuchEntityException
      */


### PR DESCRIPTION
The secret keys in the admin are still bugging things. This is a quick work around.